### PR TITLE
Fix content-type header bug in upload

### DIFF
--- a/lib/api/base-server.ts
+++ b/lib/api/base-server.ts
@@ -104,10 +104,9 @@ export class ApiClientServer {
   async upload<T>(endpoint: string, formData: FormData, options: RequestInit = {}): Promise<T> {
     const token = getCookie('access_token');
     
-    // Create headers
-    const headers = new Headers({
-      'Content-Type': 'multipart/form-data'
-    });
+    // Create headers without explicitly setting Content-Type. The runtime will
+    // automatically include the correct multipart boundary when using FormData.
+    const headers = new Headers();
     
     // Add any additional headers
     if (options.headers) {

--- a/lib/api/base.ts
+++ b/lib/api/base.ts
@@ -139,10 +139,9 @@ export class ApiClient {
   async upload<T>(endpoint: string, formData: FormData, options: RequestInit = {}): Promise<T> {
     const token = getCookie('access_token');
     
-    // Create headers
-    const headers = new Headers({
-      'Content-Type': 'multipart/form-data'
-    });
+    // Create headers without explicitly setting Content-Type so that the
+    // browser can automatically add the correct multipart boundary
+    const headers = new Headers();
     
     // Add any additional headers
     if (options.headers) {


### PR DESCRIPTION
## Summary
- avoid explicitly setting `Content-Type: multipart/form-data` for file uploads
  so that the browser/runtime can add the correct boundary automatically

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842159220fc8328a94b170b5f462181